### PR TITLE
Attempts to add proper document structure when first element encountered is a closing tag

### DIFF
--- a/src/NUglify/Html/HtmlParser.cs
+++ b/src/NUglify/Html/HtmlParser.cs
@@ -895,6 +895,13 @@ namespace NUglify.Html
 
                     CurrentParent.AppendChild(invalidTag);
 
+                    // if only <html> exists in the stack, attempt to create missing structure
+                    if (stack.Count == 1)
+                    {
+                        var parent = CurrentParent;
+                        TryCreateOptionalStart(ref parent, invalidTag);
+                    }
+
                     if (descriptor != null && descriptor.EndKind == TagEndKind.AutoSelfClosing)
                     {
                         invalidTag.Kind = ElementKind.SelfClosing;


### PR DESCRIPTION
This resolves dropped text when using HtmlToText method on an HTML fragment where the first tag encountered is a closing tag identified in issue #119 

Checks for end element being the first element encountered by checking stack.Count==1. Then will attempt to apply existing document structure repairing logic already present in the parser.