### PR TITLE
Fix transformation of some assignment operators

### DIFF
--- a/src/NUglify.Tests/TestData/JS/Expected/Operators/Assign.js
+++ b/src/NUglify.Tests/TestData/JS/Expected/Operators/Assign.js
@@ -1,1 +1,1 @@
-function rho(foo,bar){var a=foo*bar,b=(foo,bar),c=a*a;b+=foo||bar;c=(foo,bar);c=(b=5)+6;a=b=c=null;c=b+=a;a=foo+bar+10-5;a=foo?bar:0}
+function rho(foo,bar){var a=foo*bar,b=(foo,bar),c=a*a;b+=foo||bar;c=(foo,bar);c=(b=5)+6;a=b=c=null;c=b+=a;a=foo+bar+10-5;a=foo?bar:0}function bitwisexor(foo,bar){var a=foo*bar^5}function unsignedrightshift(foo){var c=foo>>>3}

--- a/src/NUglify.Tests/TestData/JS/Input/Operators/Assign.js
+++ b/src/NUglify.Tests/TestData/JS/Input/Operators/Assign.js
@@ -11,3 +11,12 @@ function rho(foo, bar)
   a = foo ? bar : 0;
 }
 
+function bitwisexor(foo, bar) {
+    var a = foo * bar;
+    a ^= 5;
+}
+
+function unsignedrightshift(foo) {
+    var c = foo;
+    c >>>= 3;
+}

--- a/src/NUglify/JavaScript/JSScanner.cs
+++ b/src/NUglify/JavaScript/JSScanner.cs
@@ -1491,7 +1491,8 @@ namespace NUglify.JavaScript
         /// <returns>true if right-associative</returns>
         public static bool IsRightAssociativeOperator(JSToken token)
         {
-            return JSToken.Assign <= token && token <= JSToken.ConditionalIf;
+            return (JSToken.Assign <= token && token <= JSToken.ConditionalIf)
+                || token == JSToken.Exponent;
         }
 
         /// <summary>

--- a/src/NUglify/JavaScript/JSToken.cs
+++ b/src/NUglify/JavaScript/JSToken.cs
@@ -88,6 +88,8 @@ namespace NUglify.JavaScript
         Plus = FirstBinaryOperator,     // +
         Minus,                          // -
         Multiply,                       // *
+        Exponent,                       // **
+
         Divide,                         // /
         Modulo,                         // %
         BitwiseAnd,                     // &
@@ -96,6 +98,9 @@ namespace NUglify.JavaScript
         LeftShift,                      // <<
         RightShift,                     // >>
         UnsignedRightShift,             // >>>
+        LogicalAnd,                     // &&
+        LogicalOr,                      // ||
+        NullishCoalesce,                // ??
 
         Equal,                          // ==
         NotEqual,                       // !=
@@ -106,17 +111,12 @@ namespace NUglify.JavaScript
         GreaterThan,                    // >
         GreaterThanEqual,               // >=
 
-        LogicalAnd,                     // &&
-        LogicalOr,                      // ||
-        
-        NullishCoalesce,                // ??
-
         InstanceOf,
         In,                             // in
         Of,                             // of
         Comma,                          // ,
 
-        Assign,                         // =
+        Assign,                         // =   // MUST FOLLOW order as in FirstBinaryOperator (replacement is done as a delta in JSScanner.StripAssignment)
         PlusAssign,                     // +=
         MinusAssign,                    // -=
         MultiplyAssign,                 // *=
@@ -133,8 +133,6 @@ namespace NUglify.JavaScript
         LogicalAndAssign,               // &&=
         LogicalNullishAssign,           // ??=
         LastAssign = LogicalNullishAssign,
-
-        Exponent,                       // **
 
         ConditionalIf,                  // ? // MUST FOLLOW LastBinaryOp
         Colon,                          // :


### PR DESCRIPTION
Due to a different order of some operators with regards to the assignment operator counterparts, they are incorrectly replaced in the output. 

This is a regression compared to AjaxMin, and looks like it was caused by the addition of the Exponentation operator (new in ES2016)