### PR TITLE
Multiple functions with spaces inbetween in selector not supported #280

### DIFF
--- a/src/NUglify.Tests/Css/Bugs.cs
+++ b/src/NUglify.Tests/Css/Bugs.cs
@@ -70,6 +70,8 @@ namespace NUglify.Tests.Css
 
             Assert.AreEqual(":is(.container):is(.bold){font-weight:bold;}", Uglify.Css(":is(.container):is(.bold) { font-weight: bold; }").Code);
 
+            Assert.AreEqual(".container :is(.bold){font-weight:bold;}", Uglify.Css(".container :is(.bold) { font-weight: bold; }").Code);
+
             // Assert whether extra unnecessary spaces around parentheses are removed:
             Assert.AreEqual(":is(.container) :is(.bold){font-weight:bold;}", Uglify.Css(":is(.container ) :is(.bold ) { font-weight: bold; }").Code);
 

--- a/src/NUglify.Tests/Css/Bugs.cs
+++ b/src/NUglify.Tests/Css/Bugs.cs
@@ -62,5 +62,13 @@ namespace NUglify.Tests.Css
         {
 	        TestHelper.Instance.RunTest();
         }
+        
+        [Test]
+        public void Bug280()
+        {
+            Assert.AreEqual(":is(.container) :is(.bold){font-weight:bold;}", Uglify.Css(":is(.container) :is(.bold) { font-weight: bold; }").Code);
+
+            Assert.AreEqual(":is(.container):is(.bold){font-weight:bold;}", Uglify.Css(":is(.container):is(.bold) { font-weight: bold; }").Code);
+        }
     }
 }

--- a/src/NUglify.Tests/Css/Bugs.cs
+++ b/src/NUglify.Tests/Css/Bugs.cs
@@ -66,9 +66,45 @@ namespace NUglify.Tests.Css
         [Test]
         public void Bug280()
         {
-            Assert.AreEqual(":is(.container) :is(.bold){font-weight:bold;}", Uglify.Css(":is(.container) :is(.bold) { font-weight: bold; }").Code);
+            Assert.AreEqual(":is(.container) :is(.bold){font-weight:bold;}", Uglify.Css(":is(.container) :is(.bold) { font-weight: bold; }").Code);            
 
             Assert.AreEqual(":is(.container):is(.bold){font-weight:bold;}", Uglify.Css(":is(.container):is(.bold) { font-weight: bold; }").Code);
+
+            // Assert whether extra unnecessary spaces around parentheses are removed:
+            Assert.AreEqual(":is(.container) :is(.bold){font-weight:bold;}", Uglify.Css(":is(.container ) :is(.bold ) { font-weight: bold; }").Code);
+
+            // Assert a more extensive scenario:
+            Assert.AreEqual("body{font-family:'Franklin Gothic Medium','Arial Narrow',Arial,sans-serif}:root{--blue:'blue';--five:5px;--width:100px;--half-width:calc(var(--width)/2);--half-width-with-indent:calc(var(--half-width) + 16px);--half-width-with-indent:calc(10% + var(--half-width) + 16px)}.margin{margin:calc(2*var(--five));padding:var(--half-width-with-indent)}:is(.container) :is(.bold){font-weight:bold;}:is(.container) :where(.bold){grid-template-areas:'myArea myArea myArea myArea myArea';}div :is(.test),div:is(.test){color:var(--blue);}",
+                 Uglify.Css(@"body {
+    font-family: 'Franklin Gothic Medium', 'Arial Narrow', Arial, sans-serif;
+}
+
+:root {
+    --blue: 'blue';
+    --five: 5px;
+    --width: 100px;
+    --half-width: calc(var(--width) / 2);
+    --half-width-with-indent: calc(var(--half-width) + 16px);
+    --half-width-with-indent: calc(10% + var(--half-width) + 16px);
+}
+
+.margin {
+    margin: calc(2 * var(--five));
+    padding: var(--half-width-with-indent);
+}
+
+
+:is(.container) :is(.bold) {
+    font-weight: bold;
+}
+:is(.container) :where(.bold) {
+    grid-template-areas: 'myArea myArea myArea myArea myArea';
+}
+div :is(.test),
+div:is(.test) {
+    color: var(--blue);
+}
+").Code);
         }
     }
 }

--- a/src/NUglify/Css/CssParser.cs
+++ b/src/NUglify/Css/CssParser.cs
@@ -4200,12 +4200,12 @@ namespace NUglify.Css
 
         static bool NeedsSpaceBefore(string text)
         {
-            return text == null ? false : !("{}()[],;".Contains(text));
+            return text == null ? false : !("{}[],;".Contains(text));
         }
 
         static bool NeedsSpaceAfter(string text)
         {
-            return text == null ? false : !("{}()[],;:".Contains(text));
+            return text == null ? false : !("{}[],;:".Contains(text));
         }
 
         #endregion

--- a/src/NUglify/Css/CssParser.cs
+++ b/src/NUglify/Css/CssParser.cs
@@ -4200,12 +4200,12 @@ namespace NUglify.Css
 
         static bool NeedsSpaceBefore(string text)
         {
-            return text == null ? false : !("{}[],;".Contains(text));
+            return text == null ? false : !("{}()[],;".Contains(text));
         }
 
         static bool NeedsSpaceAfter(string text)
         {
-            return text == null ? false : !("{}[],;:".Contains(text));
+            return text == null ? false : !("{}([],;:".Contains(text));
         }
 
         #endregion


### PR DESCRIPTION
The following selector now minifies correct:

```
:is(.container) :is(.bold) {
    font-weight: bold;
}
```

`:is(.container) :is(.bold){font-weight: bold;}`