### PR TITLE
Repro for failing object destructuring

### DIFF
--- a/src/NUglify.Tests/JavaScript/ES2015.cs
+++ b/src/NUglify.Tests/JavaScript/ES2015.cs
@@ -102,6 +102,12 @@ namespace NUglify.Tests.JavaScript
             TestHelper.Instance.RunTest();
         }
 
+        [Test]
+        public void ObjectDestructuringAssignment()
+        {
+            TestHelper.Instance.RunTest();
+        }
+
         //[Test]
         public void Modules()
         {

--- a/src/NUglify.Tests/NUglify.Tests.csproj
+++ b/src/NUglify.Tests/NUglify.Tests.csproj
@@ -593,6 +593,9 @@
     <Content Include="TestData\JS\Expected\ES2015\ConciseProperties.js">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="TestData\JS\Expected\ES2015\ObjectDestructuringAssignment.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="TestData\JS\Expected\ES2019\OptionalCatchBinding.js">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -2977,6 +2980,9 @@
     <None Include="TestData\JS\Input\CommandLine\Expression.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <Content Include="TestData\JS\Input\ES2015\ObjectDestructuringAssignment.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="TestData\JS\Input\Literals\TemplateLiteralsEscaped.js">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/NUglify.Tests/TestData/JS/Expected/Bugs/Bug290.js
+++ b/src/NUglify.Tests/TestData/JS/Expected/Bugs/Bug290.js
@@ -1,1 +1,1 @@
-﻿let foo,bar;({foo,bar}={foo:42,bar:!0})
+﻿let foo,bar;({foo,bar}={foo:42,bar:!0});({foo,bar}=fooBar)

--- a/src/NUglify.Tests/TestData/JS/Expected/ES2015/ObjectDestructuringAssignment.js
+++ b/src/NUglify.Tests/TestData/JS/Expected/ES2015/ObjectDestructuringAssignment.js
@@ -1,0 +1,1 @@
+﻿let{op,lhs,rhs}=getASTNode(),{foo,bar}=fooBar;({op,lhs,rhs}=getASTNode());({foo,bar}=fooBar)

--- a/src/NUglify.Tests/TestData/JS/Input/Bugs/Bug290.js
+++ b/src/NUglify.Tests/TestData/JS/Input/Bugs/Bug290.js
@@ -1,2 +1,4 @@
 ﻿let foo, bar;
 ({ foo, bar } = { foo: 42, bar: true });
+// similar but with variable being destructured
+({ foo, bar } = fooBar);

--- a/src/NUglify.Tests/TestData/JS/Input/ES2015/ObjectDestructuringAssignment.js
+++ b/src/NUglify.Tests/TestData/JS/Input/ES2015/ObjectDestructuringAssignment.js
@@ -1,0 +1,7 @@
+﻿// http://es6-features.org/#ObjectMatchingShorthandNotation
+let { op, lhs, rhs } = getASTNode();
+let { foo, bar } = fooBar;
+
+// similar but assigning without declaring variables (parenthesis are required in these cases)
+({ op, lhs, rhs } = getASTNode());
+({ foo, bar } = fooBar);


### PR DESCRIPTION
Seems like the fix for #290 did not cover all edge cases. This is a more complete repro