### PR TITLE
Test all input-files with short line-breaks

### DIFF
--- a/src/NUglify.Tests/App.config
+++ b/src/NUglify.Tests/App.config
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
     </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.3" newVersion="4.1.1.3" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/src/NUglify.Tests/JavaScript/AllJavascriptSyntaxTest.cs
+++ b/src/NUglify.Tests/JavaScript/AllJavascriptSyntaxTest.cs
@@ -1,0 +1,17 @@
+﻿using NUglify.Tests.JavaScript.Common;
+using NUnit.Framework;
+
+namespace NUglify.Tests.JavaScript
+{
+	[TestFixture]
+	public class AllJavascriptSyntaxTest
+	{
+		/// <summary>
+		/// check all possible files in input-directory for syntax errors after minification
+		/// </summary>
+		[Test]
+		public void SyntaxTestForAllFilesLineBreaks() {
+			TestHelper.Instance.RunSyntaxTestForAllFilesLineBreaks();
+		}
+	}
+}

--- a/src/NUglify.Tests/NUglify.Tests.csproj
+++ b/src/NUglify.Tests/NUglify.Tests.csproj
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.ClearScript.V8.Native.win-x86.7.3.1\build\Microsoft.ClearScript.V8.Native.win-x86.props" Condition="Exists('..\packages\Microsoft.ClearScript.V8.Native.win-x86.7.3.1\build\Microsoft.ClearScript.V8.Native.win-x86.props')" />
+  <Import Project="..\packages\Microsoft.ClearScript.V8.Native.win-x64.7.3.1\build\Microsoft.ClearScript.V8.Native.win-x64.props" Condition="Exists('..\packages\Microsoft.ClearScript.V8.Native.win-x64.7.3.1\build\Microsoft.ClearScript.V8.Native.win-x64.props')" />
+  <Import Project="..\packages\NUnit.3.13.3\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.13.3\build\NUnit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -43,13 +46,55 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="ClearScript.Core, Version=7.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.ClearScript.Core.7.3.1\lib\net45\ClearScript.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="ClearScript.V8, Version=7.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.ClearScript.V8.7.3.1\lib\net45\ClearScript.V8.dll</HintPath>
+    </Reference>
+    <Reference Include="ClearScript.V8.ICUData, Version=7.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.ClearScript.V8.ICUData.7.3.1\lib\netstandard1.0\ClearScript.V8.ICUData.dll</HintPath>
+    </Reference>
+    <Reference Include="ClearScript.Windows, Version=7.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.ClearScript.Windows.7.3.1\lib\net45\ClearScript.Windows.dll</HintPath>
+    </Reference>
+    <Reference Include="ClearScript.Windows.Core, Version=7.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.ClearScript.Windows.Core.7.3.1\lib\net45\ClearScript.Windows.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="mscorlib" />
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework, Version=3.13.3.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.13.3\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http, Version=4.1.1.3, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.Http.4.3.4\lib\net46\System.Net.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
@@ -98,6 +143,7 @@
     <Compile Include="Html\TestCollapseWhiteSpaces.cs" />
     <Compile Include="Html\TestScripts.cs" />
     <Compile Include="Html\TestStyles.cs" />
+    <Compile Include="JavaScript\AllJavascriptSyntaxTest.cs" />
     <Compile Include="JavaScript\ArrayHandling.cs" />
     <Compile Include="JavaScript\AspNet.cs" />
     <Compile Include="JavaScript\Assignments.cs" />
@@ -166,6 +212,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="packages.config" />
     <None Include="project.json" />
     <Content Include="TestData\Core\Expected\NUglifyTask\Combined.min.css">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -4187,6 +4234,14 @@
   <ItemGroup />
   <Import Project="$(MSBuildThisFileDirectory)..\NUglify.shared.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit.3.13.3\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.13.3\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.ClearScript.V8.Native.win-x64.7.3.1\build\Microsoft.ClearScript.V8.Native.win-x64.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ClearScript.V8.Native.win-x64.7.3.1\build\Microsoft.ClearScript.V8.Native.win-x64.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.ClearScript.V8.Native.win-x86.7.3.1\build\Microsoft.ClearScript.V8.Native.win-x86.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ClearScript.V8.Native.win-x86.7.3.1\build\Microsoft.ClearScript.V8.Native.win-x86.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/NUglify.Tests/NUglify.Tests.csproj
+++ b/src/NUglify.Tests/NUglify.Tests.csproj
@@ -2,7 +2,6 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.ClearScript.V8.Native.win-x86.7.3.1\build\Microsoft.ClearScript.V8.Native.win-x86.props" Condition="Exists('..\packages\Microsoft.ClearScript.V8.Native.win-x86.7.3.1\build\Microsoft.ClearScript.V8.Native.win-x86.props')" />
   <Import Project="..\packages\Microsoft.ClearScript.V8.Native.win-x64.7.3.1\build\Microsoft.ClearScript.V8.Native.win-x64.props" Condition="Exists('..\packages\Microsoft.ClearScript.V8.Native.win-x64.7.3.1\build\Microsoft.ClearScript.V8.Native.win-x64.props')" />
-  <Import Project="..\packages\NUnit.3.13.3\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.13.3\build\NUnit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -65,8 +64,8 @@
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.13.3.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.13.3\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.5.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/NUglify.Tests/NUglify.Tests.csproj
+++ b/src/NUglify.Tests/NUglify.Tests.csproj
@@ -4234,14 +4234,6 @@
   <ItemGroup />
   <Import Project="$(MSBuildThisFileDirectory)..\NUglify.shared.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\NUnit.3.13.3\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.13.3\build\NUnit.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.ClearScript.V8.Native.win-x64.7.3.1\build\Microsoft.ClearScript.V8.Native.win-x64.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ClearScript.V8.Native.win-x64.7.3.1\build\Microsoft.ClearScript.V8.Native.win-x64.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.ClearScript.V8.Native.win-x86.7.3.1\build\Microsoft.ClearScript.V8.Native.win-x86.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ClearScript.V8.Native.win-x86.7.3.1\build\Microsoft.ClearScript.V8.Native.win-x86.props'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/NUglify.Tests/NUglify.Tests.nuget.props
+++ b/src/NUglify.Tests/NUglify.Tests.nuget.props
@@ -15,7 +15,13 @@
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
+  <ImportGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
+    <Import Project="$(NuGetPackageRoot)microsoft.clearscript.v8.native.win-x86\7.3.1\build\Microsoft.ClearScript.V8.Native.win-x86.props" Condition="Exists('$(NuGetPackageRoot)microsoft.clearscript.v8.native.win-x86\7.3.1\build\Microsoft.ClearScript.V8.Native.win-x86.props')" />
+    <Import Project="$(NuGetPackageRoot)microsoft.clearscript.v8.native.win-x64\7.3.1\build\Microsoft.ClearScript.V8.Native.win-x64.props" Condition="Exists('$(NuGetPackageRoot)microsoft.clearscript.v8.native.win-x64\7.3.1\build\Microsoft.ClearScript.V8.Native.win-x64.props')" />
+  </ImportGroup>
   <PropertyGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
     <PkgNUnit3TestAdapter Condition=" '$(PkgNUnit3TestAdapter)' == '' ">C:\Users\Andrew Bullock\.nuget\packages\nunit3testadapter\3.5.0</PkgNUnit3TestAdapter>
+    <PkgMicrosoft_ClearScript_V8_Native_win-x86 Condition=" '$(PkgMicrosoft_ClearScript_V8_Native_win-x86)' == '' ">C:\Users\Andrew Bullock\.nuget\packages\microsoft.clearscript.v8.native.win-x86\7.3.1</PkgMicrosoft_ClearScript_V8_Native_win-x86>
+    <PkgMicrosoft_ClearScript_V8_Native_win-x64 Condition=" '$(PkgMicrosoft_ClearScript_V8_Native_win-x64)' == '' ">C:\Users\Andrew Bullock\.nuget\packages\microsoft.clearscript.v8.native.win-x64\7.3.1</PkgMicrosoft_ClearScript_V8_Native_win-x64>
   </PropertyGroup>
 </Project>

--- a/src/NUglify.Tests/packages.config
+++ b/src/NUglify.Tests/packages.config
@@ -10,7 +10,7 @@
   <package id="Microsoft.ClearScript.V8.Native.win-x86" version="7.3.1" targetFramework="net461" />
   <package id="Microsoft.ClearScript.Windows" version="7.3.1" targetFramework="net461" />
   <package id="Microsoft.ClearScript.Windows.Core" version="7.3.1" targetFramework="net461" />
-  <package id="NUnit" version="3.13.3" targetFramework="net461" />
+  <package id="NUnit" version="3.5.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net461" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net461" />
   <package id="System.Memory" version="4.5.4" targetFramework="net461" />

--- a/src/NUglify.Tests/packages.config
+++ b/src/NUglify.Tests/packages.config
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Esprima" version="3.0.0-beta-3" targetFramework="net461" />
+  <package id="Jint" version="3.0.0-beta-2039" targetFramework="net461" />
+  <package id="Microsoft.ClearScript" version="7.3.1" targetFramework="net461" />
+  <package id="Microsoft.ClearScript.Core" version="7.3.1" targetFramework="net461" />
+  <package id="Microsoft.ClearScript.V8" version="7.3.1" targetFramework="net461" />
+  <package id="Microsoft.ClearScript.V8.ICUData" version="7.3.1" targetFramework="net461" />
+  <package id="Microsoft.ClearScript.V8.Native.win-x64" version="7.3.1" targetFramework="net461" />
+  <package id="Microsoft.ClearScript.V8.Native.win-x86" version="7.3.1" targetFramework="net461" />
+  <package id="Microsoft.ClearScript.Windows" version="7.3.1" targetFramework="net461" />
+  <package id="Microsoft.ClearScript.Windows.Core" version="7.3.1" targetFramework="net461" />
+  <package id="NUnit" version="3.13.3" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net461" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net461" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net461" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net461" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net461" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net461" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
+</packages>

--- a/src/NUglify.Tests/project.json
+++ b/src/NUglify.Tests/project.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "NUnit": "3.5.0",
-    "NUnit3TestAdapter": "3.5.0"
+    "NUnit3TestAdapter": "3.5.0",
+	"Microsoft.ClearScript": "7.3.1"
   }
 }

--- a/src/NUglify/JavaScript/Visitors/OutputVisitor.cs
+++ b/src/NUglify/JavaScript/Visitors/OutputVisitor.cs
@@ -3985,7 +3985,14 @@ namespace NUglify.JavaScript.Visitors
                     Unindent();
                     if (wrapInParens)
                     {
-                        OutputPossibleLineBreak(')');
+                        if (node.FunctionType == FunctionType.ArrowFunction) 
+                        {
+                            Output(')');
+                        }
+                        else 
+                        {
+                            OutputPossibleLineBreak(')');
+                        }
                         MarkSegment(node, null, node.ParameterDeclarations.Context);
                     }
                 }
@@ -3993,7 +4000,7 @@ namespace NUglify.JavaScript.Visitors
                 {
                     // empty arrow function parameters need the empty parentheses
                     OutputPossibleLineBreak('(');
-                    OutputPossibleLineBreak(')');
+                    Output(')');
                     m_startOfStatement = false;
                 }
 

--- a/src/NUglify/JavaScript/Visitors/OutputVisitor.cs
+++ b/src/NUglify/JavaScript/Visitors/OutputVisitor.cs
@@ -767,7 +767,7 @@ namespace NUglify.JavaScript.Visitors
                 {
                     if (node.OptionalChaining)
                     {
-                        OutputPossibleLineBreak('?');
+                        Output('?');
                         OutputPossibleLineBreak('.');
                     }
 
@@ -2549,7 +2549,7 @@ namespace NUglify.JavaScript.Visitors
                 }
 
                 if (node.OptionalChaining)
-                    OutputPossibleLineBreak('?');
+                    Output('?');
                 OutputPossibleLineBreak('.');
                 
                 MarkSegment(node, node.Name, node.NameContext);


### PR DESCRIPTION
While using this library, we got some issues with line-breaks that are just waiting to occur in the real world.
After the second issue, we wrote a generic unit test.
This test takes all input files, minifies them with "-line:1" and tries to execute the minified code using the Microsoft.ClearScript-Engine. We found a total of four distinct issues when it comes to line-breaks:
- OptionalChaining ('?.'): Line-break between '?' and '.' is not allowed. Already fixed in this PR.
- ArrowFunctions ('=>'): Line-break between '()' and '=>' is not allowed. Already fixed in this PR.
- yield-statement: if a line-break is added directly after the yield, JS returns undefined instead of the value. We know too little about NUglify to fix this.
- async: It seems like there must not be a line-break after the keyword. Not yet fixed. We know too little about NUglify to fix this.

Additionally, the expected output for "ES6.js" simply does not compile and should be fixed.

Of course, the test ignores all js-files that are invalid from the start (e.g. because of placeholders).

How should we proceed with this?

Please find the current output of the test attached.

[Test Output for SyntaxTestForAllFilesLineBreaks.Hipigog.txt](https://github.com/trullock/NUglify/files/9423928/Test.Output.for.SyntaxTestForAllFilesLineBreaks.Hipigog.txt)