### PR TITLE
Fix bug #279 spreads are not properties.

### DIFF
--- a/src/NUglify.Tests/TestData/JS/Expected/Bugs/Bug279.js
+++ b/src/NUglify.Tests/TestData/JS/Expected/Bugs/Bug279.js
@@ -1,1 +1,1 @@
-﻿"use strict";const config={...Manipulator.getDataAttributes(target),...Manipulator.getDataAttributes(this)}
+﻿"use strict";const config={...Manipulator.getDataAttributes(target),...Manipulator.getDataAttributes(this),...!1,...!1}

--- a/src/NUglify.Tests/TestData/JS/Input/Bugs/Bug279.js
+++ b/src/NUglify.Tests/TestData/JS/Input/Bugs/Bug279.js
@@ -1,5 +1,7 @@
 ﻿"use strict";
 const config = {
 	...Manipulator.getDataAttributes(target),
-	...Manipulator.getDataAttributes(this)
+	...Manipulator.getDataAttributes(this),
+	...(true ? false : true),
+	...(false ? true : false)
 };

--- a/src/NUglify/JavaScript/Visitors/AnalyzeNodeVisitor.cs
+++ b/src/NUglify/JavaScript/Visitors/AnalyzeNodeVisitor.cs
@@ -3370,7 +3370,7 @@ namespace NUglify.JavaScript.Visitors
 
                             if (keyName == null)
                             {
-	                            if (property.Value is UnaryExpression ue && ue.OperatorToken == JSToken.RestSpread && ue.Operand is CallExpression ce)
+	                            if (property.Value is UnaryExpression ue && ue.OperatorToken == JSToken.RestSpread)
 	                            {
 		                            keyName = property.Value.Context.ToString();
 	                            }


### PR DESCRIPTION
Fix bug #279 spreads are not properties.

The bug is back because we were only checking for `CallExpressions`, if you add two `Conditionals` it will fail again. It should be enough to disregard rests and spreads all together, they shouldn't actually be in the properties list anyway. This fixes the bug, test data modified to reproduce, with no new tests failing so we have to assume it is good.

nJoy