### PR TITLE
bug_343

### DIFF
--- a/src/NUglify.Tests/Css/Bugs.cs
+++ b/src/NUglify.Tests/Css/Bugs.cs
@@ -151,5 +151,15 @@ body
 }").Code);
         }
 
+        [Test]
+        public void Bug343()
+        {
+            Assert.AreEqual("body{border:0 none;border:0 none #f00}", Uglify.Css(@"
+body
+{
+	border: 0 none;
+	border: 0 none #f00;
+}").Code);
+        }
     }
 }

--- a/src/NUglify/Css/CssParser.cs
+++ b/src/NUglify/Css/CssParser.cs
@@ -2853,7 +2853,7 @@ namespace NUglify.Css
                         wasEmpty = false;
                     }
 
-                    if (parsingNoneReducibleProperty && CurrentTokenText.ToLowerInvariant() == "none")
+                    if (parsingNoneReducibleProperty && CurrentTokenText.ToLowerInvariant() == "none" && m_lastOutputString == ":")
 	                    Append('0');
                     else
 	                    AppendCurrent();


### PR DESCRIPTION
parsingNoneReducibleProperty should only apply if it's the first token for the property (#343)