### PR TITLE
Added new CssSetting AbbreviateHexColor

### DIFF
--- a/src/NUglify/Css/CssParser.cs
+++ b/src/NUglify/Css/CssParser.cs
@@ -3385,7 +3385,7 @@ namespace NUglify.Css
                         // we can collapse it to either #rrggbb or #rgb
                         // calculate the full hex string and crunch it
                         var fullCode = "#{0:x2}{1:x2}{2:x2}".FormatInvariant(rgb[0], rgb[1], rgb[2]);
-                        var result= CrunchHexColor(fullCode, Settings.ColorNames, m_noColorAbbreviation);
+                        var result= CrunchHexColor(fullCode, Settings.ColorNames, m_noColorAbbreviation || !Settings.AbbreviateHexColor);
                         Append(result.Color);
 
                         // set the flag so we know we don't want to add the closing paren
@@ -3555,7 +3555,7 @@ namespace NUglify.Css
 
                 if (colorHash.Length == 4 || colorHash.Length == 5 || colorHash.Length == 7 || colorHash.Length == 9)
                 {
-	                var result = CrunchHexColor(colorHash, Settings.ColorNames, m_noColorAbbreviation);
+	                var result = CrunchHexColor(colorHash, Settings.ColorNames, m_noColorAbbreviation || !Settings.AbbreviateHexColor);
 
 	                if (!result.IsValidColor)
 		                return Parsed.False;
@@ -4728,7 +4728,7 @@ namespace NUglify.Css
                     else if (CurrentTokenType == TokenType.ReplacementToken)
                     {
                         // a replacement token is a color hash
-                        var result = CrunchHexColor(text, Settings.ColorNames, m_noColorAbbreviation);
+                        var result = CrunchHexColor(text, Settings.ColorNames, m_noColorAbbreviation || !Settings.AbbreviateHexColor);
                         text = result.Color;
                     }
                 }

--- a/src/NUglify/Css/CssSettings.cs
+++ b/src/NUglify/Css/CssSettings.cs
@@ -36,6 +36,7 @@ namespace NUglify.Css
 			FixIE8Fonts = true;
 			ExcludeVendorPrefixes = new List<string>();
 			DecodeEscapes = true;
+            AbbreviateHexColor = true;
 		}
 
 		/// <summary>
@@ -75,8 +76,9 @@ namespace NUglify.Css
 				BlocksStartOnSameLine = BlocksStartOnSameLine,
 				RemoveEmptyBlocks = RemoveEmptyBlocks,
 				IgnoreRazorEscapeSequence = IgnoreRazorEscapeSequence,
-				DecodeEscapes = DecodeEscapes
-			};
+				DecodeEscapes = DecodeEscapes,
+                AbbreviateHexColor = AbbreviateHexColor
+            };
 
 			// add the resource strings (if any)
 			newSettings.AddResourceStrings(ResourceStrings);
@@ -99,9 +101,14 @@ namespace NUglify.Css
 		public CssColor ColorNames { get; set; }
 
 		/// <summary>
-		/// Gets or sets CommentMode setting. Default is Important.
+		/// Gets or sets a value indicating whether to abbreviate hex colors to #rgb(a) format. Default is true
 		/// </summary>
-		public CssComment CommentMode { get; set; }
+		public bool AbbreviateHexColor { get; set; }
+
+        /// <summary>
+        /// Gets or sets CommentMode setting. Default is Important.
+        /// </summary>
+        public CssComment CommentMode { get; set; }
 
 		/// <summary>
 		/// Gets or sets a value indicating whether to minify the javascript within expression functions. Deault is true.


### PR DESCRIPTION
Disable/enable abbreviate hex colors to #rgb(a) format. Default is true
Resolves feature request #369 