### PR TITLE
fixes bug #384 do not strip fr unit when reducing zeros

### DIFF
--- a/src/NUglify.Tests/Css/Bugs.cs
+++ b/src/NUglify.Tests/Css/Bugs.cs
@@ -172,5 +172,12 @@ body
 }
 ").Code);
         }
+
+        [Test]
+        public void Bug384()
+        {
+            var uglifyResult = Uglify.Css("grid-template-rows: 0fr 0px 0% 0em;");
+            Assert.AreEqual("grid-template-rows: 0fr 0 0% 0;", uglifyResult.Code);
+        }
     }
 }

--- a/src/NUglify/Css/CssParser.cs
+++ b/src/NUglify/Css/CssParser.cs
@@ -2876,6 +2876,7 @@ namespace NUglify.Css
                 case TokenType.Time:
                 case TokenType.Frequency:
                 case TokenType.Resolution:
+                case TokenType.Fraction:
                     if (wasEmpty)
                     {
                         Append(' ');

--- a/src/NUglify/Css/CssScanner.cs
+++ b/src/NUglify/Css/CssScanner.cs
@@ -1086,7 +1086,6 @@ namespace NUglify.Css
                             case "VM":          // viewport width or height, whichever is smaller of the two (use VMIN)
                             case "VMIN":        // minimum of the viewport's height and width
                             case "VMAX":        // maximum of the viewport's height and width
-                            case "FR":          // fraction of available space
                             case "GR":          // grid unit
                             case "GD":          // text grid unit
                                 tokenType = TokenType.RelativeLength;
@@ -1127,6 +1126,10 @@ namespace NUglify.Css
                             case "DB":          // decibel
                             case "ST":          // semitones
                                 tokenType = TokenType.Speech;
+                                break;
+                            // browsers do not animate grid-template-* if the fr unit is stripped
+                            case "FR":          // fraction of available space
+                                tokenType = TokenType.Dimension;
                                 break;
                         }
 

--- a/src/NUglify/Css/CssScanner.cs
+++ b/src/NUglify/Css/CssScanner.cs
@@ -1127,9 +1127,8 @@ namespace NUglify.Css
                             case "ST":          // semitones
                                 tokenType = TokenType.Speech;
                                 break;
-                            // browsers do not animate grid-template-* if the fr unit is stripped
                             case "FR":          // fraction of available space
-                                tokenType = TokenType.Dimension;
+                                tokenType = TokenType.Fraction;
                                 break;
                         }
 
@@ -1145,7 +1144,8 @@ namespace NUglify.Css
                             && tokenType != TokenType.Angle
                             && tokenType != TokenType.Time
                             && tokenType != TokenType.Frequency
-                            && tokenType != TokenType.Resolution)
+                            && tokenType != TokenType.Resolution
+                            && tokenType != TokenType.Fraction)
                         {
                             token = new CssToken(TokenType.Number, num, m_context);
                         }

--- a/src/NUglify/Css/CssToken.cs
+++ b/src/NUglify/Css/CssToken.cs
@@ -184,6 +184,7 @@ namespace NUglify.Css
         ProgId,
         Character,
         Comment,
+        Fraction,
 
         // CSS3 paged media at-symbols
         TopLeftCornerSymbol,


### PR DESCRIPTION
…n't animate changes to the grid-template-rows or grid-template-columns property when the unit changes from 1fr to 0.