### PR TITLE
Fixes issue with default values and javascript destructuring (#394)

### DIFF
--- a/src/NUglify.Tests/JavaScript/Bugs.cs
+++ b/src/NUglify.Tests/JavaScript/Bugs.cs
@@ -388,5 +388,10 @@ namespace NUglify.Tests.JavaScript
 	        TestHelper.Instance.RunTest("-rename:all");
         }
 
+        [Test]
+        public void Bug394()
+        {
+            TestHelper.Instance.RunTest("-rename:all");
+        }
     }
 }

--- a/src/NUglify.Tests/NUglify.Tests.csproj
+++ b/src/NUglify.Tests/NUglify.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -573,6 +573,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="TestData\JS\Expected\Bugs\Bug391.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestData\JS\Expected\Bugs\Bug394.js">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="TestData\JS\Expected\Bugs\Bug70.js">
@@ -2965,6 +2968,9 @@
     <None Include="TestData\JS\Input\Bugs\Bug306.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <Content Include="TestData\JS\Input\Bugs\Bug394.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="TestData\JS\Input\Bugs\Bug57.js">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/NUglify.Tests/TestData/JS/Expected/Bugs/Bug201.js
+++ b/src/NUglify.Tests/TestData/JS/Expected/Bugs/Bug201.js
@@ -1,1 +1,1 @@
-﻿const sum=function({t=2,n=3}){return t+n},sum2=({t=2,n=3})=>t+n
+﻿const sum=function({foo:t=2,dummy:n=3}){return t+n},sum2=({foo2:t=2,dummy2:n=3})=>t+n

--- a/src/NUglify.Tests/TestData/JS/Expected/Bugs/Bug345.js
+++ b/src/NUglify.Tests/TestData/JS/Expected/Bugs/Bug345.js
@@ -1,1 +1,1 @@
-"use strict";function test1({n=1,t=2}={}){console.log(n+t)}function test2(n=1,t=2){console.log(n+t)}
+"use strict";function test1({verylongname_x:n=1,verylongname_y:t=2}={}){console.log(n+t)}function test2(n=1,t=2){console.log(n+t)}

--- a/src/NUglify.Tests/TestData/JS/Expected/Bugs/Bug394.js
+++ b/src/NUglify.Tests/TestData/JS/Expected/Bugs/Bug394.js
@@ -1,0 +1,1 @@
+﻿const someFunc=({val:t,op:n="eq"})=>{var i=n+t};var args={val:"va",op:"contains"};someFunc(args)

--- a/src/NUglify.Tests/TestData/JS/Input/Bugs/Bug394.js
+++ b/src/NUglify.Tests/TestData/JS/Input/Bugs/Bug394.js
@@ -1,0 +1,10 @@
+﻿const someFunc = ({ val, op = 'eq' }) => {
+    var useOp = op + val;
+};
+
+var args = {
+    val: 'va',
+    op: 'contains'
+};
+
+someFunc(args);

--- a/src/NUglify/JavaScript/JSParser.cs
+++ b/src/NUglify/JavaScript/JSParser.cs
@@ -4926,10 +4926,20 @@ namespace NUglify.JavaScript
 
                 // just a name lookup; the property name is implicit
                 ParsedVersion = ScriptVersion.EcmaScript6;
+                var fieldContext = m_currentToken.Clone();
+                var fieldScanner = m_scanner.Clone();
                 value = ParseObjectPropertyValue(isBindingPattern);
 
                 if (isBindingPattern && m_currentToken.Is(JSToken.Assign))
                 {
+                    // we need to back up to properly parse the field name
+                    if (m_settings.LocalRenaming != LocalRenaming.KeepAll)
+                    {
+                        m_currentToken = fieldContext;
+                        m_scanner = fieldScanner;
+                        field = ParseObjectLiteralFieldName();
+                    }
+
                     var assignContext = m_currentToken.Clone();
                     GetNextToken();
                     value = new InitializerNode(assignContext.Clone())


### PR DESCRIPTION
original property name is now correctly persisted when using javascript object destructuring with default values and property renaming  (#394)