### PR TITLE
[CSS] Handle custom identifiers.

### DIFF
--- a/src/NUglify.Tests/TestData/CSS/Expected/Values/Grids.css
+++ b/src/NUglify.Tests/TestData/CSS/Expected/Values/Grids.css
@@ -1,1 +1,1 @@
-﻿#grid{width:500px;grid-columns:"a" auto "b" minmax(min-content,1fr) "b" "c" "d" ("e" 40px)[2] (auto)[5]}
+﻿#grid{width:500px;grid-columns:"a" auto "b" minmax(min-content,1fr) "b" "c" "d" ("e" 40px)[2] (auto)[5];grid-template-columns:[first-column] 15% [second-column] 10% [third-column] auto}

--- a/src/NUglify.Tests/TestData/CSS/Input/Values/Grids.css
+++ b/src/NUglify.Tests/TestData/CSS/Input/Values/Grids.css
@@ -1,4 +1,5 @@
 ﻿#grid {
     width: 500px;
     grid-columns: "a" auto "b" minmax(min-content, 1fr) "b" "c" "d" ("e" 40px)[2] (auto)[5];
+    grid-template-columns: [ first-column ] 15% [second-column  ] 10% [  third-column] auto;
 }

--- a/src/NUglify.Tests/project.json
+++ b/src/NUglify.Tests/project.json
@@ -18,6 +18,7 @@
     }
   },
   "dependencies": {
-    "NUnit": "4.1.0"
+    "NUnit": "4.1.0",
+    "NUnit3TestAdapter": "4.5.0"
   }
 }

--- a/src/NUglify/Css/CssParser.cs
+++ b/src/NUglify/Css/CssParser.cs
@@ -2921,7 +2921,37 @@ namespace NUglify.Css
                     break;
 
                 case TokenType.Character:
-                    if (CurrentTokenText == "(")
+                    // Handle custom identifiers (e.g. used with grid-template-columns)
+                    if (CurrentTokenText == "[")
+                    {
+                        if (wasEmpty)
+                        {
+                            // if we had skipped any space, then add one now
+                            if (m_skippedSpace)
+                            {
+                                Append(' ');
+                            }
+
+                            wasEmpty = false;
+                        }
+                        AppendCurrent();
+                        SkipSpace();
+                        if (CurrentTokenType != TokenType.Identifier)
+                        {
+                            ReportError(0, CssErrorCode.ExpectedIdentifier, CurrentTokenText);
+                        }
+                        AppendCurrent();
+                        SkipSpace();
+                        if (CurrentTokenText != "]")
+                        {
+                            ReportError(0, CssErrorCode.ExpectedClosingBracket, CurrentTokenText);
+                        }
+                        AppendCurrent();
+                        SkipSpace();
+                        parsed = Parsed.True;
+                        break;
+                    }
+                    else if (CurrentTokenText == "(")
                     {
                         // the term starts with an opening paren.
                         // parse an expression followed by the close paren.


### PR DESCRIPTION
We can have css like this:

```
    grid-template-columns: [first-column] 15% [second-column] 10% [third-column] auto;
```

Currently this runs in an error in CssParser. This PR makes the parser handle these custom identifiers.