### PR TITLE
418: Fixed issue where 2 getters with the same name where 1 of the getters is static resulted in "JS1323: Duplicate class element name"

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.21.13 (24 February 2025)
+- Fixed issue where 2 getters with the same name where 1 of the getters is static resulted in "JS1323: Duplicate class element name"
+
 ## v1.21.12 (21 February 2025)
 - Fixed issue where null coalescing operator combined with "||" or "&&" resulted in syntax errors.
 

--- a/src/NUglify.Tests/JavaScript/Classes.cs
+++ b/src/NUglify.Tests/JavaScript/Classes.cs
@@ -43,5 +43,11 @@ namespace NUglify.Tests.JavaScript
         {
             TestHelper.Instance.RunErrorTest(JSError.NoIdentifier, JSError.NoIdentifier, JSError.NoLeftCurly, JSError.NoRightCurly);
         }
+
+        [Test]
+        public void ClassNormalAndStaticProperty()
+        {
+            TestHelper.Instance.RunErrorTest();
+        }
     }
 }

--- a/src/NUglify.Tests/NUglify.Tests.csproj
+++ b/src/NUglify.Tests/NUglify.Tests.csproj
@@ -1711,6 +1711,9 @@
     <Content Include="TestData\JS\Expected\Classes\ClassExpr.js">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="TestData\JS\Expected\Classes\ClassNormalAndStaticProperty.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="TestData\JS\Expected\Comprehensions\ArrayComp.js">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -3149,6 +3152,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="TestData\JS\Input\Classes\ClassExpr.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestData\JS\Input\Classes\ClassNormalAndStaticProperty.js">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="TestData\JS\Input\Comprehensions\ArrayComp.js">

--- a/src/NUglify.Tests/TestData/JS/Expected/Classes/ClassNormalAndStaticProperty.js
+++ b/src/NUglify.Tests/TestData/JS/Expected/Classes/ClassNormalAndStaticProperty.js
@@ -1,0 +1,1 @@
+﻿class Foo{static get bar(){return""}get bar(){return Foo.bar()}}

--- a/src/NUglify.Tests/TestData/JS/Input/Classes/ClassNormalAndStaticProperty.js
+++ b/src/NUglify.Tests/TestData/JS/Input/Classes/ClassNormalAndStaticProperty.js
@@ -1,0 +1,5 @@
+﻿class Foo
+{
+    static get bar() { return ""; }
+    get bar() { return Foo.bar(); }
+}

--- a/src/NUglify/JavaScript/Visitors/AnalyzeNodeVisitor.cs
+++ b/src/NUglify/JavaScript/Visitors/AnalyzeNodeVisitor.cs
@@ -2026,17 +2026,13 @@ namespace NUglify.JavaScript.Visitors
 
         static string ClassElementKeyName(FunctionType funcType, string name, bool isStatic)
         {
-            switch (funcType)
-            {
-                case FunctionType.Getter:
-                    return "get_" + name;
+            var funcTypeName = funcType switch {
+                FunctionType.Getter => "get_",
+                FunctionType.Setter => "set_",
+                _ => "method_"
+            };
 
-                case FunctionType.Setter:
-                    return "set_" + name;
-
-                default:
-                    return (isStatic ? "static_" : string.Empty) + "method_" + name;
-            }
+            return $"{(isStatic ? "static_" : string.Empty)}{funcTypeName}{name}";
         }
 
         public override void Visit(ComprehensionNode node)

--- a/src/NUglify/NUglify.csproj
+++ b/src/NUglify/NUglify.csproj
@@ -18,7 +18,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/trullock/NUglify</RepositoryUrl>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.0</NetStandardImplicitPackageVersion>
-    <Version>1.21.12</Version>
+    <Version>1.21.13</Version>
     <PackageLicenseExpression></PackageLicenseExpression>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>


### PR DESCRIPTION
Fixes #418 by also prepending `static_` to the `ClassElementKeyName` for getters and setters.
Added unit test for this case.