### PR TITLE
Add support for CSS clamp function with + operator (Fixes issue #424).

### DIFF
--- a/src/NUglify.Tests/Css/Bugs.cs
+++ b/src/NUglify.Tests/Css/Bugs.cs
@@ -206,6 +206,16 @@ body
 	--tw-contain-style:
 }").HasErrors, Is.False);
         }
-        
+
+        [Test]
+        public void Bug424()
+        {
+           var uglifyResult = Uglify.Css(@"h1 {
+                font-size: clamp(1.3rem, 1.4rem + 0.3vw, 1.7rem); }");
+
+            //TestHelper.Instance.RunTest();  //this don't check if HasErrors is true or false! Doing manually
+            Assert.That(uglifyResult.Code, Is.EqualTo("h1{font-size:clamp(1.3rem,1.4rem + .3vw,1.7rem)}"));
+            Assert.That(uglifyResult.HasErrors, Is.False);    
+        }
     }
 }

--- a/src/NUglify.Tests/NUglify.Tests.csproj
+++ b/src/NUglify.Tests/NUglify.Tests.csproj
@@ -392,6 +392,9 @@
     <Content Include="TestData\CSS\Expected\AtRules\Supports.css">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="TestData\CSS\Expected\Bugs\Bug424.css">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="TestData\CSS\Expected\Bugs\Bug270.css">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -450,6 +453,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="TestData\CSS\Input\Bugs\Bug412.css">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestData\CSS\Input\Bugs\Bug424.css">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="TestData\CSS\Input\Bugs\Bug74.css">

--- a/src/NUglify.Tests/TestData/CSS/Expected/Bugs/Bug424.css
+++ b/src/NUglify.Tests/TestData/CSS/Expected/Bugs/Bug424.css
@@ -1,0 +1,1 @@
+﻿h1{font-size:clamp(1.3rem,1.4rem + .3vw,1.7rem)}

--- a/src/NUglify.Tests/TestData/CSS/Input/Bugs/Bug424.css
+++ b/src/NUglify.Tests/TestData/CSS/Input/Bugs/Bug424.css
@@ -1,0 +1,3 @@
+﻿h1 {
+    font-size: clamp(1.3rem, 1.4rem + 0.3vw, 1.7rem);
+}

--- a/src/NUglify/Css/CssParser.cs
+++ b/src/NUglify/Css/CssParser.cs
@@ -2561,9 +2561,9 @@ namespace NUglify.Css
                         else
                         {
                             // don't care if this finds one or not, just process it
-	                        ParseCombinator();
+                            ParseCombinator();
 
-	                        return ParseSelector();
+                            return ParseSelector();
                         }
                         break;
 
@@ -3174,6 +3174,10 @@ namespace NUglify.Css
                     case "MIN(":
                     case "MAX(":
                         parsed = ParseMinMax();
+                        break;
+
+                    case "CLAMP(":
+                        parsed = ParseClamp();
                         break;
 
                     default:
@@ -3871,6 +3875,53 @@ namespace NUglify.Css
 
             return parsed;
         }
+
+        Parsed ParseClamp()
+        {
+            var parsed = Parsed.False;
+            if (CurrentTokenType == TokenType.Function
+                && string.Compare(GetRoot(CurrentTokenText), "clamp(", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                Append(CurrentTokenText.ToLowerInvariant());
+                SkipSpace();
+
+                // clamp() has three parameters: min, preferred, max
+                for (int i = 0; i < 3; i++)
+                {
+                    if (ParseSum() != Parsed.True)
+                    {
+                        ReportError(0, CssErrorCode.ExpectedExpression, CurrentTokenText);
+                    }
+
+                    if (i < 2) // Expecting a comma between values
+                    {
+                        if (CurrentTokenType == TokenType.Character && CurrentTokenText == ",")
+                        {
+                            AppendCurrent();
+                            SkipSpace();
+                        }
+                        else
+                        {
+                            ReportError(0, CssErrorCode.ExpectedComma, CurrentTokenText);
+                        }
+                    }
+                }
+
+                if (CurrentTokenType == TokenType.Character && CurrentTokenText == ")")
+                {
+                    AppendCurrent();
+                    SkipSpace();
+                    parsed = Parsed.True;
+                }
+                else
+                {
+                    ReportError(0, CssErrorCode.ExpectedClosingParenthesis, CurrentTokenText);
+                }
+            }
+
+            return parsed;
+        }
+
 
         #endregion
 


### PR DESCRIPTION
### Description

This pull request adds support for the CSS `clamp` function with the `+` operator. It includes the following changes:
- Edits the CSS parser to recognize and correctly parse the `clamp` function with the `+` operator.
- Adds a test case for the `clamp` function in the `Bug424` test and related test assets.

### Related Issue

Fixes issue #424

### Testing

- Added a new test case in `Bug424` to verify the correct parsing of the `clamp` function.
- All existing css related tests pass.

### Checklist

- [x] Code changes are covered by tests.
- [x] All CSS related tests pass.

### Notes

Initially used TestHelper.Instance.RunTest(); to run the test but notice that this don't check if HasErrors is true or false! Then did the parse calling manually. But maybe this function should check HasErrors with Assert.
