### PR TITLE
Add support for CSS clamp function with + operator (Fixes issue #424) - v1.1

### DIFF
--- a/src/NUglify.Tests/Css/Bugs.cs
+++ b/src/NUglify.Tests/Css/Bugs.cs
@@ -206,6 +206,16 @@ body
 	--tw-contain-style:
 }").HasErrors, Is.False);
         }
-        
+
+        [Test]
+        public void Bug424()
+        {
+            var uglifyResult = Uglify.Css(@"h1 {
+                font-size: clamp(1.3rem, 1.4rem + 0.3vw, 1.7rem); }");
+
+            //TestHelper.Instance.RunTest();  //this don't check if HasErrors is true or false! Doing manually
+            Assert.That(uglifyResult.Code, Is.EqualTo("h1{font-size:clamp(1.3rem,1.4rem + .3vw,1.7rem)}"));
+            Assert.That(uglifyResult.HasErrors, Is.False);
+        }
     }
 }


### PR DESCRIPTION
### Description
This pull request adds support for the CSS clamp function with the + operator. It includes the following changes:

- Edits the CSS parser to recognize and correctly parse the clamp function with the + operator.
- Adds a test case for the clamp function in the Bug424 test.

### Related Issue
Fixes issue #424 

### Testing
- Added a new test case in Bug424 to verify the correct parsing of the clamp function.
- All existing css related tests pass.

### Checklist
- Code changes are covered by tests.
- All CSS related tests pass.

### Notes
1. Initially, TestHelper.Instance.RunTest(); was used to run the test, but it was noticed that this does not check whether HasErrors is true or false. So, the parsing was done manually. However, maybe this function should check HasErrors using an Assert.
2. Next, it would be good to review the need to support the latest CSS syntax, as it may not be fully compatible with the most recent versions. Maybe clamp() was just an example.
3. This is the v1.1 of this pull request with cleaner code.