### PR TITLE
Fix quoted class and object method names in JS parser

### DIFF
--- a/src/NUglify.Tests/JavaScript/Bugs.cs
+++ b/src/NUglify.Tests/JavaScript/Bugs.cs
@@ -566,6 +566,20 @@ var func2 = function () {
             Assert.That(result.Code, Is.EqualTo("function make(n){const[t=n]=[];return t}"));
         }
 
+        [Test]
+        public void Bug421()
+        {
+            var result = Uglify.Js("class Test{'allow-cache'(){}}");
+            Assert.That(result.HasErrors, Is.False,
+                () => "Uglify errors:\n" + string.Join("\n", result.Errors));
+            Assert.That(result.Code, Is.EqualTo("class Test{\"allow-cache\"(){}}"));
+
+            result = Uglify.Js("let o={'allow-cache'(){}}");
+            Assert.That(result.HasErrors, Is.False,
+                () => "Uglify errors:\n" + string.Join("\n", result.Errors));
+            Assert.That(result.Code, Is.EqualTo("let o={\"allow-cache\"(){}}"));
+        }
+
         private void AssertMinified(string source, string expected)
         {
             var result = Uglify.Js(source);

--- a/src/NUglify/JavaScript/JSParser.cs
+++ b/src/NUglify/JavaScript/JSParser.cs
@@ -2868,6 +2868,7 @@ namespace NUglify.JavaScript
         private FunctionObject ParseFunction(FunctionType functionType, SourceContext fncCtx)
         {
             BindingIdentifier name = null;
+            ObjectLiteralField literalName = null;
             ArrayLiteral computedName = null;
             bool inExpression = (functionType == FunctionType.Expression);
 
@@ -2908,6 +2909,11 @@ namespace NUglify.JavaScript
                 // TODO: error handling
 		        computedName = arrayLiteral as ArrayLiteral;
             }
+            else if ((functionType == FunctionType.Method || functionType == FunctionType.Getter || functionType == FunctionType.Setter)
+                && (m_currentToken.Is(JSToken.StringLiteral) || m_currentToken.Is(JSToken.IntegerLiteral) || m_currentToken.Is(JSToken.NumericLiteral)))
+            {
+                literalName = ParseObjectLiteralFieldName();
+            }
             else
             {
                 string identifier = JSKeyword.CanBeIdentifier(m_currentToken.Token);
@@ -2946,10 +2952,10 @@ namespace NUglify.JavaScript
                 }
             }
 
-            return ParseFunctionPart2(functionType, fncCtx, name, computedName, isGenerator, isAsync);
+            return ParseFunctionPart2(functionType, fncCtx, name, literalName, computedName, isGenerator, isAsync);
         }
 
-        private FunctionObject ParseFunctionPart2(FunctionType functionType, SourceContext context, BindingIdentifier name, ArrayLiteral computedName, bool isGenerator, bool isAsync)
+        private FunctionObject ParseFunctionPart2(FunctionType functionType, SourceContext context, BindingIdentifier name, ObjectLiteralField literalName, ArrayLiteral computedName, bool isGenerator, bool isAsync)
         {
 	        BlockStatement body = null;
 	        if (m_currentToken.IsNot(JSToken.LeftParenthesis))
@@ -2966,7 +2972,7 @@ namespace NUglify.JavaScript
 		               && m_currentToken.IsNot(JSToken.Semicolon)
 		               && m_currentToken.IsNot(JSToken.EndOfFile))
 		        {
-			        name.Context.UpdateWith(m_currentToken);
+			        name?.Context.UpdateWith(m_currentToken);
 			        GetNextToken();
 			        expandedIndentifier = true;
 		        }
@@ -2976,8 +2982,15 @@ namespace NUglify.JavaScript
 		        // name, so just report that we expected an open paren at this point.
 		        if (expandedIndentifier)
 		        {
-			        name.Name = name.Context.Code;
-			        name.Context.HandleError(JSError.FunctionNameMustBeIdentifier, false);
+			        if (name != null)
+			        {
+				        name.Name = name.Context.Code;
+				        name.Context.HandleError(JSError.FunctionNameMustBeIdentifier, false);
+			        }
+			        else
+			        {
+				        ReportError(JSError.NoLeftParenthesis, context);
+			        }
 		        }
 		        else
 		        {
@@ -3035,6 +3048,7 @@ namespace NUglify.JavaScript
 	        {
 		        FunctionType = functionType,
 		        Binding = name,
+		        LiteralName = literalName,
 		        ComputedName = computedName,
 		        ParameterDeclarations = formalParameters,
 		        Body = body,
@@ -3355,7 +3369,7 @@ namespace NUglify.JavaScript
 
 	            if (m_currentToken.Is(JSToken.LeftParenthesis))
 	            {
-		            var function = ParseFunctionPart2(FunctionType.Method, ctx, null, computedName, false, false);
+		            var function = ParseFunctionPart2(FunctionType.Method, ctx, null, null, computedName, false, false);
 		            return function;
 	            }
             }
@@ -5071,7 +5085,7 @@ namespace NUglify.JavaScript
 
 	            if (m_currentToken.Is(JSToken.LeftParenthesis))
 	            {
-                    value = ParseFunctionPart2(FunctionType.Method, ctx, null, astNode as ArrayLiteral, false, false);
+                    value = ParseFunctionPart2(FunctionType.Method, ctx, null, null, astNode as ArrayLiteral, false, false);
 	            }
 	            else
 	            {

--- a/src/NUglify/JavaScript/Syntax/FunctionObject.cs
+++ b/src/NUglify/JavaScript/Syntax/FunctionObject.cs
@@ -23,6 +23,7 @@ namespace NUglify.JavaScript.Syntax
     public class FunctionObject : AstNode
     {
 	    BindingIdentifier m_binding;
+	    ObjectLiteralField m_literalName;
 	    AstNodeList m_parameters;
 	    BlockStatement m_body;
 
@@ -34,6 +35,12 @@ namespace NUglify.JavaScript.Syntax
         {
             get => m_binding;
             set => ReplaceNode(ref m_binding, value);
+        }
+
+        public ObjectLiteralField LiteralName
+        {
+            get => m_literalName;
+            set => ReplaceNode(ref m_literalName, value);
         }
 
         public ArrayLiteral ComputedName { get; set; }
@@ -185,7 +192,7 @@ namespace NUglify.JavaScript.Syntax
         {
             get
             {
-                return EnumerateNonNullNodes(Binding, ParameterDeclarations, Body);
+                return EnumerateNonNullNodes(Binding, LiteralName, ParameterDeclarations, Body);
             }
         }
 
@@ -194,6 +201,11 @@ namespace NUglify.JavaScript.Syntax
             if (Binding == oldNode)
             {
                 Binding = newNode as BindingIdentifier;
+                return true;
+            }
+            else if (LiteralName == oldNode)
+            {
+                LiteralName = newNode as ObjectLiteralField;
                 return true;
             }
             else if (Body == oldNode)

--- a/src/NUglify/JavaScript/Visitors/AnalyzeNodeVisitor.cs
+++ b/src/NUglify/JavaScript/Visitors/AnalyzeNodeVisitor.cs
@@ -1996,11 +1996,20 @@ namespace NUglify.JavaScript.Visitors
                     {
                         string functionName;
                         var functionObject = element as FunctionObject;
-                        if (functionObject != null 
-                            && functionObject.Binding != null 
-                            && !(functionName = functionObject.Binding.Name).IsNullOrWhiteSpace())
+                        if (functionObject != null)
                         {
-                            var errorContext = functionObject.Binding.Context ?? functionObject.Context;
+                            functionName = functionObject.Binding?.Name;
+                            var errorContext = functionObject.Binding?.Context ?? functionObject.LiteralName?.Context ?? functionObject.Context;
+
+                            if (functionName.IsNullOrWhiteSpace() && functionObject.LiteralName != null)
+                            {
+                                functionName = functionObject.LiteralName.Name;
+                            }
+
+                            if (functionName.IsNullOrWhiteSpace())
+                            {
+                                continue;
+                            }
 
                             // the keyed name is the function type (get/set/other) plus the name
                             // make sure there's no duplicate with this name

--- a/src/NUglify/JavaScript/Visitors/OutputVisitor.cs
+++ b/src/NUglify/JavaScript/Visitors/OutputVisitor.cs
@@ -1891,6 +1891,28 @@ namespace NUglify.JavaScript.Visitors
             }
         }
 
+        void OutputMethodLiteralName(ObjectLiteralField node)
+        {
+            if (node == null)
+            {
+                return;
+            }
+
+            if (JSScanner.IsValidIdentifierPart(lastCharacter))
+            {
+                Output(' ');
+            }
+
+            if (node.PrimitiveType == PrimitiveType.String)
+            {
+                Visit(node as ConstantWrapper);
+            }
+            else
+            {
+                Visit(node as ConstantWrapper);
+            }
+        }
+
         public void Visit(FunctionObject node)
         {
             // TODO: 205
@@ -1969,7 +1991,18 @@ namespace NUglify.JavaScript.Visitors
                             MarkSegment(node, node.Binding.Name, node.Binding.Context);
                             SetContextOutputPosition(node.Context);
                         }
-                    } else if (node.ComputedName != null)
+                    }
+                    else if (node.LiteralName != null)
+                    {
+                        isAnonymous = false;
+                        if (settings.SymbolsMap != null)
+	                        m_functionStack.Push(node.LiteralName.Name);
+
+                        OutputMethodLiteralName(node.LiteralName);
+                        MarkSegment(node, node.LiteralName.Name, node.LiteralName.Context);
+                        SetContextOutputPosition(node.Context);
+                    }
+                    else if (node.ComputedName != null)
                     {
                         Visit(node.ComputedName);
                     }


### PR DESCRIPTION
Fixes #421