### PR TITLE
Fix object rest destructuring binding parsing

### DIFF
--- a/src/NUglify.Tests/JavaScript/Bugs.cs
+++ b/src/NUglify.Tests/JavaScript/Bugs.cs
@@ -589,6 +589,15 @@ var func2 = function () {
             Assert.That(result.Code, Is.EqualTo("class TestElement extends HTMLElement{static[Symbol.hasInstance](){return!0}}"));
         }
 
+        [Test]
+        public void Bug425()
+        {
+            var result = Uglify.Js("$m=(e,t,n,o,r,s)=>{const{uid:a=t,...i}=n;}");
+            Assert.That(result.HasErrors, Is.False,
+                () => "Uglify errors:\n" + string.Join("\n", result.Errors));
+            Assert.That(result.Code, Is.EqualTo("$m=(n,t,i)=>{const{uid:r=t,...u}=i}"));
+        }
+
         private void AssertMinified(string source, string expected)
         {
             var result = Uglify.Js(source);

--- a/src/NUglify/JavaScript/JSParser.cs
+++ b/src/NUglify/JavaScript/JSParser.cs
@@ -5035,7 +5035,7 @@ namespace NUglify.JavaScript
                 var restContext = m_currentToken.Clone();
                 GetNextToken();
 
-                value = ParseExpression(true);
+                value = ParseObjectPropertyValue(isBindingPattern);
 
                 if (value != null)
                 {


### PR DESCRIPTION
Parse object rest properties as bindings inside destructuring patterns so rest identifiers are declared and renamed correctly.

Fixes #425